### PR TITLE
add `pass_proc` flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Cargo.lock
 */Cargo.lock
 */target
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@
 					'control',
 					[
 						new Extension.Palette.Block('receiveTestEvent'),
+						new Extension.Palette.Block('printProcess'),
 					],
 					SpriteMorph
 				),
@@ -63,6 +64,7 @@
 					'control',
 					[
 						new Extension.Palette.Block('receiveTestEvent'),
+						new Extension.Palette.Block('printProcess'),
 					],
 					StageMorph
 				),
@@ -127,6 +129,14 @@
 					'on test event',
 					[],
 					function () { return ExampleExtension_fns.receive_test_event(); }
+				).for(SpriteMorph, StageMorph),
+				new Extension.Block(
+					'printProcess',
+					'command',
+					'control',
+					'print process',
+					[],
+					function () { return ExampleExtension_fns.print_process(this, ); }
 				).for(SpriteMorph, StageMorph),
 
             ];
@@ -193,7 +203,7 @@
     path = path.substring(0, path.lastIndexOf("/"));
     var s = document.createElement('script');
     s.type = "module";
-    s.innerHTML = `import init, {hello_name, hello_world, is_even, print_extension_name, print_hello_world, receive_test_event, repeat_text} from '${path}/pkg/netsblox_extension_rs.js';
+    s.innerHTML = `import init, {hello_name, hello_world, is_even, print_extension_name, print_hello_world, print_process, receive_test_event, repeat_text} from '${path}/pkg/netsblox_extension_rs.js';
     
     
         await init();
@@ -204,6 +214,7 @@
 		window.ExampleExtension_fns.is_even = is_even;
 		window.ExampleExtension_fns.print_extension_name = print_extension_name;
 		window.ExampleExtension_fns.print_hello_world = print_hello_world;
+		window.ExampleExtension_fns.print_process = print_process;
 		window.ExampleExtension_fns.receive_test_event = receive_test_event;
 		window.ExampleExtension_fns.repeat_text = repeat_text;
         `;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 use netsblox_extension_macro::*;
 use netsblox_extension_util::*;
-use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 use web_sys::console;
 extern crate console_error_panic_hook;
 use std::panic;
@@ -93,4 +93,10 @@ pub fn print_extension_name() {
     } else {
         console::log_1(&INFO.name.to_owned().into());
     }
+}
+
+#[wasm_bindgen]
+#[netsblox_extension_block(name = "printProcess", category = "control", spec = "print process", target = netsblox_extension_util::TargetObject::Both, pass_proc = true)]
+pub fn print_process(this: JsValue) {
+    console::log_1(&this);
 }


### PR DESCRIPTION
Enables a new attr called `pass_proc` for `netsblox_extension_block` that makes it pass the `this` object representing the calling process. If not specified, does not pass `this`, which preserves backwards compatibility. I haven't done anything with this so far, but we should just be able to receive it as a generic jsvalue param as the first argument.