### PR TITLE
more ret type checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,10 @@
 						new Extension.Palette.Block('receiveTestEvent'),
 						new Extension.Palette.Block('printProcess'),
 						new Extension.Palette.Block('explode'),
+						new Extension.Palette.Block('explicitCommand'),
+						new Extension.Palette.Block('fallibleCommand'),
+						new Extension.Palette.Block('fallibleReporter'),
+						new Extension.Palette.Block('falliblePredicate'),
 					],
 					SpriteMorph
 				),
@@ -67,6 +71,10 @@
 						new Extension.Palette.Block('receiveTestEvent'),
 						new Extension.Palette.Block('printProcess'),
 						new Extension.Palette.Block('explode'),
+						new Extension.Palette.Block('explicitCommand'),
+						new Extension.Palette.Block('fallibleCommand'),
+						new Extension.Palette.Block('fallibleReporter'),
+						new Extension.Palette.Block('falliblePredicate'),
 					],
 					StageMorph
 				),
@@ -158,6 +166,38 @@
 					[],
 					function (v0) { return window.ExampleExtension_fns.add_all(v0); }
 				).for(SpriteMorph, StageMorph),
+				new Extension.Block(
+					'explicitCommand',
+					'command',
+					'control',
+					'explicit command',
+					[],
+					function () { return window.ExampleExtension_fns.explicit_command(); }
+				).for(SpriteMorph, StageMorph),
+				new Extension.Block(
+					'fallibleCommand',
+					'command',
+					'control',
+					'fallible command',
+					[],
+					function () { return window.ExampleExtension_fns.fallible_command(); }
+				).for(SpriteMorph, StageMorph),
+				new Extension.Block(
+					'fallibleReporter',
+					'reporter',
+					'control',
+					'fallible reporter',
+					[],
+					function () { return window.ExampleExtension_fns.fallible_reporter(); }
+				).for(SpriteMorph, StageMorph),
+				new Extension.Block(
+					'falliblePredicate',
+					'predicate',
+					'control',
+					'fallible predicate',
+					[],
+					function () { return window.ExampleExtension_fns.fallible_predicate(); }
+				).for(SpriteMorph, StageMorph),
 
             ];
         }
@@ -199,14 +239,18 @@
     path = path.substring(0, path.lastIndexOf("/"));
     var s = document.createElement('script');
     s.type = "module";
-    s.innerHTML = `import init, {add_all, explode, hello_name, hello_world, is_even, print_extension_name, print_hello_world, print_process, receive_test_event, repeat_text} from '${path}/pkg/netsblox_extension_rs.js';
+    s.innerHTML = `import init, {add_all, explicit_command, explode, fallible_command, fallible_predicate, fallible_reporter, hello_name, hello_world, is_even, print_extension_name, print_hello_world, print_process, receive_test_event, repeat_text} from '${path}/pkg/netsblox_extension_rs.js';
     
     
         await init();
 
         window.ExampleExtension_fns = {};
 		window.ExampleExtension_fns.add_all = add_all;
+		window.ExampleExtension_fns.explicit_command = explicit_command;
 		window.ExampleExtension_fns.explode = explode;
+		window.ExampleExtension_fns.fallible_command = fallible_command;
+		window.ExampleExtension_fns.fallible_predicate = fallible_predicate;
+		window.ExampleExtension_fns.fallible_reporter = fallible_reporter;
 		window.ExampleExtension_fns.hello_name = hello_name;
 		window.ExampleExtension_fns.hello_world = hello_world;
 		window.ExampleExtension_fns.is_even = is_even;

--- a/netsblox-extension-util/src/lib.rs
+++ b/netsblox-extension-util/src/lib.rs
@@ -219,7 +219,19 @@ fn recreate_netsblox_extension_block(item: &ItemFn, attr: &Attribute) -> CustomB
         instance.block_type = match &item.sig.output {
             syn::ReturnType::Default => BlockType::Command,
             syn::ReturnType::Type(_, b) => match b.as_ref() {
-                syn::Type::Path(p) if &p.path.segments.first().unwrap().ident.to_string() == "bool" => BlockType::Predicate,
+                syn::Type::Tuple(t) if t.elems.is_empty() => BlockType::Command,
+                syn::Type::Path(p) if p.path.segments.first().unwrap().ident.to_string() == "bool" => BlockType::Predicate,
+                syn::Type::Path(p) if p.path.segments.first().unwrap().ident.to_string() == "Result" => match &p.path.segments.first().unwrap().arguments {
+                    syn::PathArguments::AngleBracketed(x) => match x.args.first().unwrap() {
+                        syn::GenericArgument::Type(c) => match c {
+                            syn::Type::Tuple(t) if t.elems.is_empty() => BlockType::Command,
+                            syn::Type::Path(p) if p.path.segments.first().unwrap().ident.to_string() == "bool" => BlockType::Predicate,
+                            _ => BlockType::Reporter
+                        }
+                        _ => BlockType::Reporter
+                    }
+                    _ => BlockType::Reporter
+                }
                 _ => BlockType::Reporter
             },
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,3 +116,27 @@ pub fn add_all(vals: Vec<JsValue>) -> f64 {
     }
     res
 }
+
+#[wasm_bindgen]
+#[netsblox_extension_block(name = "explicitCommand", category = "control", spec = "explicit command")]
+pub fn explicit_command() -> () {
+    ()
+}
+
+#[wasm_bindgen]
+#[netsblox_extension_block(name = "fallibleCommand", category = "control", spec = "fallible command")]
+pub fn fallible_command() -> Result<(), f64> {
+    Ok(())
+}
+
+#[wasm_bindgen]
+#[netsblox_extension_block(name = "fallibleReporter", category = "control", spec = "fallible reporter")]
+pub fn fallible_reporter() -> Result<f64, f64> {
+    Ok(12.5)
+}
+
+#[wasm_bindgen]
+#[netsblox_extension_block(name = "falliblePredicate", category = "control", spec = "fallible predicate")]
+pub fn fallible_predicate() -> Result<bool, f64> {
+    Ok(true)
+}


### PR DESCRIPTION
Added a few more block type deduction checks:

- `()` (explicit) is now a command (was previously a reporter)
- `Result<(), T>` is now a command (was previously a reporter)
- `Result<bool, T>` is now a predicate (was previously a reporter)