### PR TITLE
extra block options

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,7 @@
 						new Extension.Palette.Block('repeatString'),
 						new Extension.Palette.Block('isEven'),
 						new Extension.Palette.Block('addAll'),
+						new Extension.Palette.Block('defaultAdder'),
 					],
 					SpriteMorph
 				),
@@ -95,6 +96,7 @@
 						new Extension.Palette.Block('repeatString'),
 						new Extension.Palette.Block('isEven'),
 						new Extension.Palette.Block('addAll'),
+						new Extension.Palette.Block('defaultAdder'),
 					],
 					StageMorph
 				),
@@ -208,6 +210,14 @@
 					[],
 					function (v0) { return window.ExampleExtension_fns.picky_boi(v0); }
 				).for(SpriteMorph, StageMorph),
+				new Extension.Block(
+					'defaultAdder',
+					'reporter',
+					'operators',
+					'add %n + %n',
+					['7', '-4'],
+					function (v0, v1) { return window.ExampleExtension_fns.default_adder(v0, v1); }
+				).for(SpriteMorph, StageMorph),
 
             ];
         }
@@ -261,13 +271,14 @@
     path = path.substring(0, path.lastIndexOf("/"));
     var s = document.createElement('script');
     s.type = "module";
-    s.innerHTML = `import init, {add_all, explicit_command, explode, fallible_command, fallible_predicate, fallible_reporter, hello_name, hello_world, is_even, picky_boi, print_extension_name, print_hello_world, print_process, receive_test_event, repeat_text} from '${path}/pkg/netsblox_extension_rs.js';
+    s.innerHTML = `import init, {add_all, default_adder, explicit_command, explode, fallible_command, fallible_predicate, fallible_reporter, hello_name, hello_world, is_even, picky_boi, print_extension_name, print_hello_world, print_process, receive_test_event, repeat_text} from '${path}/pkg/netsblox_extension_rs.js';
     
     
         await init();
 
         window.ExampleExtension_fns = {};
 		window.ExampleExtension_fns.add_all = add_all;
+		window.ExampleExtension_fns.default_adder = default_adder;
 		window.ExampleExtension_fns.explicit_command = explicit_command;
 		window.ExampleExtension_fns.explode = explode;
 		window.ExampleExtension_fns.fallible_command = fallible_command;

--- a/index.js
+++ b/index.js
@@ -57,11 +57,15 @@
 					[
 						new Extension.Palette.Block('receiveTestEvent'),
 						new Extension.Palette.Block('printProcess'),
+						'-',
 						new Extension.Palette.Block('explode'),
+						'-',
 						new Extension.Palette.Block('explicitCommand'),
 						new Extension.Palette.Block('fallibleCommand'),
+						'-',
 						new Extension.Palette.Block('fallibleReporter'),
 						new Extension.Palette.Block('falliblePredicate'),
+						'-',
 						new Extension.Palette.Block('pickyboi'),
 					],
 					SpriteMorph
@@ -71,11 +75,15 @@
 					[
 						new Extension.Palette.Block('receiveTestEvent'),
 						new Extension.Palette.Block('printProcess'),
+						'-',
 						new Extension.Palette.Block('explode'),
+						'-',
 						new Extension.Palette.Block('explicitCommand'),
 						new Extension.Palette.Block('fallibleCommand'),
+						'-',
 						new Extension.Palette.Block('fallibleReporter'),
 						new Extension.Palette.Block('falliblePredicate'),
+						'-',
 						new Extension.Palette.Block('pickyboi'),
 					],
 					StageMorph

--- a/netsblox-extension-util/src/lib.rs
+++ b/netsblox-extension-util/src/lib.rs
@@ -25,9 +25,10 @@ macro_rules! extract_tuple {
 }
 
 macro_rules! try_construct {
-    ($t:ident$(::$tt:ident)* { $($f:ident),*$(,)? }) => {
-        $t$(::$tt)* { $($f: $f.expect(&format!("missing {} field: {}", stringify!($t), stringify!($f)))),* }
-    };
+    ($t:ident$(::$tt:ident)* { $($f:ident),*$(,)? }) => {{
+        let ty_name = stringify!($t$(::$tt)*);
+        $t$(::$tt)* { $($f: $f.expect(&format!("missing {ty_name} field: {}", stringify!($f)))),* }
+    }};
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]

--- a/netsblox-extension-util/src/lib.rs
+++ b/netsblox-extension-util/src/lib.rs
@@ -659,7 +659,7 @@ pub fn build() -> Result<(), Box<dyn Error>>  {
             blocks_str += format!("\t\t\t\t\t'{}',\n", serde_json::to_string(&block.block_type)?.strip_prefix("\"").unwrap().strip_suffix("\"").unwrap()).as_str();
             blocks_str += format!("\t\t\t\t\t'{}',\n", serde_json::to_string(&block.category)?.strip_prefix("\"").unwrap().strip_suffix("\"").unwrap()).as_str();
             blocks_str += format!("\t\t\t\t\t'{}',\n", block.spec).as_str();
-            blocks_str += "\t\t\t\t\t[],\n";
+            blocks_str += format!("\t\t\t\t\t{},\n", block.defaults).as_str();
 
             let label_parts_str = label_parts_regex.captures_iter(block.spec).enumerate().map(|(i, _)| format!("v{i}")).collect::<Vec<_>>().join(", ");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,3 +176,9 @@ pub fn fallible_predicate() -> Result<bool, f64> {
 pub fn picky_boi(v: &JsValue) -> JsValue {
     v.clone()
 }
+
+#[wasm_bindgen]
+#[netsblox_extension_block(name = "defaultAdder", category = "operators", spec = "add %n + %n", defaults = "['7', '-4']")]
+pub fn default_adder(a: f64, b: f64) -> f64 {
+    a + b
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ pub fn print_process(this: JsValue) {
 }
 
 #[wasm_bindgen]
-#[netsblox_extension_block(name = "explode", category = "control", spec = "explode", type_override = netsblox_extension_util::BlockType::Terminator)]
+#[netsblox_extension_block(name = "explode", category = "control", spec = "explode", type_override = netsblox_extension_util::BlockType::Terminator, pad_top = true, pad_bottom = true)]
 pub fn explode() {
     panic!()
 }
@@ -160,13 +160,13 @@ pub fn fallible_command() -> Result<(), f64> {
 }
 
 #[wasm_bindgen]
-#[netsblox_extension_block(name = "fallibleReporter", category = "control", spec = "fallible reporter")]
+#[netsblox_extension_block(name = "fallibleReporter", category = "control", spec = "fallible reporter", pad_top = true)]
 pub fn fallible_reporter() -> Result<f64, f64> {
     Ok(12.5)
 }
 
 #[wasm_bindgen]
-#[netsblox_extension_block(name = "falliblePredicate", category = "control", spec = "fallible predicate")]
+#[netsblox_extension_block(name = "falliblePredicate", category = "control", spec = "fallible predicate", pad_bottom = true)]
 pub fn fallible_predicate() -> Result<bool, f64> {
     Ok(true)
 }


### PR DESCRIPTION
This adds support for a few new block options.

- `defaults` is now supported, which is just a literal string that gets injected into the block def
- `pad_top` and `pad_bottom` are new fields that cause the palette generator to emit `'-'` separator tokens before/after the block

In doing this, I also refactored some of the struct extractors to be a little stricter and shorter to add new fields in the future. They also get rid of the `Default` impls on some things and we just construct them directly from optionals with a macro. This guarantees we don't miss supporting anything (we either get a missing field error or an unused mut warning, but never a silent default).