### PR TITLE
chore: Use the repository instead of the homepage field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Gordon Stein"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-homepage = "https://github.com/gsteinLTU/netsblox-extension-rs"
+repository = "https://github.com/gsteinLTU/netsblox-extension-rs"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.